### PR TITLE
fix: grammar in "runs" section

### DIFF
--- a/__tests__/fixtures/all_fields_action.output
+++ b/__tests__/fixtures/all_fields_action.output
@@ -22,5 +22,5 @@ Default test
 
 ## Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 

--- a/__tests__/fixtures/all_fields_action_toc1.output
+++ b/__tests__/fixtures/all_fields_action_toc1.output
@@ -22,5 +22,5 @@ Default test
 
 # Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 

--- a/__tests__/fixtures/all_fields_action_toc3_cli.output
+++ b/__tests__/fixtures/all_fields_action_toc3_cli.output
@@ -22,5 +22,5 @@ Default test
 
 ### Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 

--- a/__tests__/fixtures/all_fields_readme.output
+++ b/__tests__/fixtures/all_fields_readme.output
@@ -35,7 +35,7 @@ Default test
 <!-- action-docs-runs -->
 ## Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 
 
 <!-- action-docs-runs -->

--- a/__tests__/fixtures/all_fields_readme.output.crlf
+++ b/__tests__/fixtures/all_fields_readme.output.crlf
@@ -35,7 +35,7 @@ Default test
 <!-- action-docs-runs -->
 ## Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 
 
 <!-- action-docs-runs -->

--- a/__tests__/fixtures/all_fields_readme_filled.input
+++ b/__tests__/fixtures/all_fields_readme_filled.input
@@ -33,7 +33,7 @@ Default test abc
 <!-- action-docs-runs -->
 ## Run
 
-This action is an `docker` action.
+This action is a `docker` action.
 
 
 <!-- action-docs-runs -->

--- a/__tests__/fixtures/all_fields_readme_filled.output
+++ b/__tests__/fixtures/all_fields_readme_filled.output
@@ -35,7 +35,7 @@ Default test
 <!-- action-docs-runs -->
 ## Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 
 
 <!-- action-docs-runs -->

--- a/__tests__/fixtures/default.output
+++ b/__tests__/fixtures/default.output
@@ -18,5 +18,5 @@ Default test
 
 ## Runs
 
-This action is an `node12` action.
+This action is a `node12` action.
 

--- a/__tests__/fixtures/minimal_action.output
+++ b/__tests__/fixtures/minimal_action.output
@@ -4,5 +4,5 @@ Default test
 
 ## Runs
 
-This action is an `docker` action.
+This action is a `docker` action.
 

--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -122,7 +122,7 @@ function generateActionDocs(options: DefaultOptions): ActionMarkdown {
     runs: createMarkdownSection(
       options,
       // eslint-disable-next-line i18n-text/no-en
-      `This action is an \`${yml.runs.using}\` action.`,
+      `This action is a \`${yml.runs.using}\` action.`,
       "Runs"
     ),
   };


### PR DESCRIPTION
Fixes a minor grammar issue in the "runs" section of the output: `runs.using` for custom actions will be one of "node12", "node16", "docker", or "composite". Since all of these start with consonants, putting "an" instead of "a" reads incorrectly.