### PR TITLE
feat: trim output text

### DIFF
--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -142,7 +142,7 @@ async function updateReadme(
     from: to,
     to: `<!-- action-docs-${section} -->${getLineBreak(
       options.lineBreaks
-    )}${text}${getLineBreak(
+    )}${text.trim()}${getLineBreak(
       options.lineBreaks
     )}<!-- action-docs-${section} -->`,
   });


### PR DESCRIPTION
This will trim the output text in the README removing extra white space.

Current output looks like this:
```
<!-- action-docs-outputs -->
## Outputs

| parameter | description |
| - | - |
| cache-hit | A boolean value to indicate an exact match was found for the cache. |
| elixir-version | The exact version of Elixir installed. |
| otp-version | The exact version of Erlang/OTP installed. |



<!-- action-docs-outputs -->
```

New output looks like this:
```
<!-- action-docs-outputs -->
## Outputs

| parameter | description |
| - | - |
| cache-hit | A boolean value to indicate an exact match was found for the cache. |
| elixir-version | The exact version of Elixir installed. |
| otp-version | The exact version of Erlang/OTP installed. |
<!-- action-docs-outputs -->
```