### PR TITLE
feat: remove new lines from inputs

### DIFF
--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -189,7 +189,12 @@ function getInputOutput(
       rows[i].push(
         value.required ? `\`${String(value.required)}\`` : "`false`"
       );
-      rows[i].push(value.default !== undefined ? value.default : "");
+
+      if (value.default !== undefined) {
+        rows[i].push(value.default.toString().replace(/\r\n|\r|\n/g, " "));
+      } else {
+        rows[i].push("");
+      }
     }
   }
   return { headers, rows };


### PR DESCRIPTION
This removes new lines from inputs. Some actions, like [`actions/cache`](https://github.com/actions/cache#creating-a-cache-key) take inputs via new line strings. When generating documentation for these, the new line wasn't removed causing table issues.

Before:
```
| parameter | description | required | default |
| - | - | - | - |
| cache-path | A list of files, directories, and wildcard patterns to cache and restore. By default this will cache the build and deps folder allowing for faster rebuilding. | `false` | _build
deps
 |
| cache-name | (Optional) The name of the cache. This is used to build the full cache key. By default this uses the job name which should suffice is most scenarios. If you have a custom naming scheme or want to share caches between different actions you can set it here. The reason we set this differently for each job is because tools will have different compile settings, like credo and dialyzer, and therefor have different files cached. | `false` | ${{ github.job }} |
```

After:
```
| parameter | description | required | default |
| - | - | - | - |
| cache-path | A list of files, directories, and wildcard patterns to cache and restore. By default this will cache the build and deps folder allowing for faster rebuilding. | `false` | _build deps  |
| cache-name | (Optional) The name of the cache. This is used to build the full cache key. By default this uses the job name which should suffice is most scenarios. If you have a custom naming scheme or want to share caches between different actions you can set it here. The reason we set this differently for each job is because tools will have different compile settings, like credo and dialyzer, and therefor have different files cached. | 
```