### PR TITLE
Tables: Use three hyphens in tables instead of one

### DIFF
--- a/__tests__/fixtures/all_fields_action.output
+++ b/__tests__/fixtures/all_fields_action.output
@@ -5,7 +5,7 @@ Default test
 ## Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputC | A description C | `true` | C |
@@ -16,7 +16,7 @@ Default test
 ## Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description A |
 | outputB | A description B |
 

--- a/__tests__/fixtures/all_fields_action_toc1.output
+++ b/__tests__/fixtures/all_fields_action_toc1.output
@@ -5,7 +5,7 @@ Default test
 # Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputC | A description C | `true` | C |
@@ -16,7 +16,7 @@ Default test
 # Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description A |
 | outputB | A description B |
 

--- a/__tests__/fixtures/all_fields_action_toc3_cli.output
+++ b/__tests__/fixtures/all_fields_action_toc3_cli.output
@@ -5,7 +5,7 @@ Default test
 ### Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputC | A description C | `true` | C |
@@ -16,7 +16,7 @@ Default test
 ### Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description A |
 | outputB | A description B |
 

--- a/__tests__/fixtures/all_fields_readme.output
+++ b/__tests__/fixtures/all_fields_readme.output
@@ -10,7 +10,7 @@ Default test
 ## Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputC | A description C | `true` | C |
@@ -25,7 +25,7 @@ Default test
 ## Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description A |
 | outputB | A description B |
 

--- a/__tests__/fixtures/all_fields_readme.output.crlf
+++ b/__tests__/fixtures/all_fields_readme.output.crlf
@@ -10,7 +10,7 @@ Default test
 ## Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputC | A description C | `true` | C |
@@ -25,7 +25,7 @@ Default test
 ## Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description A |
 | outputB | A description B |
 

--- a/__tests__/fixtures/all_fields_readme_filled.input
+++ b/__tests__/fixtures/all_fields_readme_filled.input
@@ -10,7 +10,7 @@ Default test abc
 ## Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputD | A description D | `false` | D |
@@ -24,7 +24,7 @@ Default test abc
 ## Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputB | A description B |
 
 

--- a/__tests__/fixtures/all_fields_readme_filled.output
+++ b/__tests__/fixtures/all_fields_readme_filled.output
@@ -10,7 +10,7 @@ Default test
 ## Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description A | `false` |  |
 | inputB | A description B | `true` |  |
 | inputC | A description C | `true` | C |
@@ -25,7 +25,7 @@ Default test
 ## Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description A |
 | outputB | A description B |
 

--- a/__tests__/fixtures/default.output
+++ b/__tests__/fixtures/default.output
@@ -5,14 +5,14 @@ Default test
 ## Inputs
 
 | parameter | description | required | default |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | inputA | A description | `false` | test |
 
 
 ## Outputs
 
 | parameter | description |
-| - | - |
+| --- | --- |
 | outputA | A description |
 
 

--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -176,7 +176,7 @@ function getInputOutput(
     type === "input"
       ? ["parameter", "description", "required", "default"]
       : ["parameter", "description"];
-  headers[1] = Array(headers[0].length).fill("-");
+  headers[1] = Array(headers[0].length).fill("---");
 
   for (let i = 0; i < Object.keys(data).length; i++) {
     const key = Object.keys(data)[i];


### PR DESCRIPTION
In order to follow the GitHub specification for tables, we want to use 3 hyphens to separate table header row from the data rows.

- Adjust tests

Refs https://github.com/npalm/action-docs/issues/275

Before:
```
| parameter | description |
| - | - |
| outputA | A description A |
| outputB | A description B |
```

After:

```
| parameter | description |
| --- | --- |
| outputA | A description A |
| outputB | A description B |
```