### PR TITLE
feat: support multi-line

### DIFF
--- a/__tests__/fixtures/action.yml
+++ b/__tests__/fixtures/action.yml
@@ -4,7 +4,15 @@ author: 'Niek Palm'
 inputs:
   inputA:
     required: false
-    description: 'A description'
+    description: |
+      A description
+      This is a multiline description
+    default: test
+  inputB:
+    required: false
+    description: |
+      This is a
+      multiline description
     default: test
 
 outputs:

--- a/__tests__/fixtures/default.output
+++ b/__tests__/fixtures/default.output
@@ -6,7 +6,8 @@ Default test
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| inputA | A description | `false` | test |
+| inputA | A description This is a multiline description  | `false` | test |
+| inputB | This is a multiline description  | `false` | test |
 
 
 ## Outputs

--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -69,10 +69,13 @@ function createMdTable(
 
   let result = "";
 
+  let abc = "abc\ndef\n";
+  // remove inner line br
+
   for (const line of tableArray) {
     result = `${result}|`;
     for (const c of line) {
-      result = `${result} ${c} |`;
+      result = `${result} ${c.replace(/(\r\n|\n|\r)/gm, " ")} |`;
     }
     result = `${result}${getLineBreak(options.lineBreaks)}`;
   }

--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -69,9 +69,6 @@ function createMdTable(
 
   let result = "";
 
-  let abc = "abc\ndef\n";
-  // remove inner line br
-
   for (const line of tableArray) {
     result = `${result}|`;
     for (const c of line) {


### PR DESCRIPTION
Basic support for multi-line. YAML multi-line strings a converted to a single line for the tables.

Example:

```yaml
inputs:
  inputA:
    required: false
    description: |
      A description
      This is a multiline description
    default: test
  inputB:
    required: false
    description: |
      This is a
      multiline description
    default: test
```

is converted to:
| parameter | description | required | default |
| --- | --- | --- | --- |
| inputA | A description This is a multiline description  | `false` | test |
| inputB | This is a multiline description  | `false` | test |

fix #344 