### PR TITLE
feat: Add support for inputs deprecationMessage

### DIFF
--- a/__tests__/action-docs-action.test.ts
+++ b/__tests__/action-docs-action.test.ts
@@ -154,6 +154,14 @@ describe("Test update readme ", () => {
       fixtureReadme: path.join(fixtureDir, "two_actions_readme.output"),
     });
   });
+
+  test("Readme for deprecated inputs", async () => {
+    await testReadme({
+      sourceFile: path.join(fixtureDir, "deprecated_input_action.yml"),
+      originalReadme: path.join(fixtureDir, "deprecated_input_action.input"),
+      fixtureReadme: path.join(fixtureDir, "deprecated_input_action.output"),
+    });
+  });
 });
 
 describe("Test usage format", () => {

--- a/__tests__/fixtures/action/deprecated_input_action.input
+++ b/__tests__/fixtures/action/deprecated_input_action.input
@@ -1,0 +1,1 @@
+<!-- action-docs-inputs action="__tests__/fixtures/action/deprecated_input_action.yml" -->

--- a/__tests__/fixtures/action/deprecated_input_action.output
+++ b/__tests__/fixtures/action/deprecated_input_action.output
@@ -1,0 +1,8 @@
+<!-- action-docs-inputs action="__tests__/fixtures/action/deprecated_input_action.yml" -->
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `inputA` | <p>This is an input<br/><em>Deprecated: This input has been deprecated</em></p> | `false` | `""` |
+| `inputB` | <p>This is an input<br/><em>Deprecated</em></p> | `false` | `""` |
+<!-- action-docs-inputs action="__tests__/fixtures/action/deprecated_input_action.yml" -->

--- a/__tests__/fixtures/action/deprecated_input_action.yml
+++ b/__tests__/fixtures/action/deprecated_input_action.yml
@@ -1,0 +1,17 @@
+name: "An Action"
+description: "Test of deprecated inputs"
+author: "Niek Palm"
+inputs:
+  inputA:
+    required: false
+    description: This is an input
+    deprecationMessage: This input has been deprecated
+  inputB:
+    required: false
+    description: This is an input
+    deprecationMessage: ''
+
+runs:
+  using: "node12"
+  main: "dist/index.js"
+  

--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -93,6 +93,7 @@ interface InputOutput {
   description?: string;
   default?: string;
   type?: InputType;
+  deprecationMessage?: string;
 }
 
 function createMdTable(
@@ -415,6 +416,15 @@ function getInputOutput(
 
       if (columnName === "name") {
         rowValue = key;
+      } else if (columnName === "description") {
+        rowValue = value[columnName];
+        if (value["deprecationMessage"] !== undefined) {
+          rowValue += "<br/>_Deprecated";
+          if (value["deprecationMessage"] !== "") {
+            rowValue += `: ${value["deprecationMessage"]}`;
+          }
+          rowValue += "_";
+        }
       } else if (columnName === "default") {
         rowValue =
           value[columnName] !== undefined && value[columnName] !== ""


### PR DESCRIPTION
Adding support for [`inputs.<input_id>.deprecationMessage`](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddeprecationmessage)

The deprecationMessage is added to the description field.