### PR TITLE
ci: add homebrew action and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: mislav/bump-homebrew-formula-action@b3327118b2153c82da63fd9cbf58942146ee99f0 # v3
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula
-          formula-name: atmos
+          formula-name: action-docs
           formula-path: Formula/a/action-docs.rb
         env:
           COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,16 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  homebrew:
+    name: "Bump Homebrew formula"
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@b3327118b2153c82da63fd9cbf58942146ee99f0 # v3
+        with:
+          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula
+          formula-name: atmos
+          formula-path: Formula/a/action-docs.rb
+        env:
+          COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,10 +30,23 @@ Optionally you can also add the following section to generate a usage guide, rep
 <!-- action-docs-usage source="action.yml" project="<project>" version="<version>" -->
 ```
 
-### Generate docs via CLI
+### Install
+
+#### npm
 
 ```bash
 npm install -g action-docs
+```
+
+#### brew
+
+```bash
+brew install action-docs
+```
+
+### Generate docs via CLI
+
+```bash
 cd <your github action>
 
 # write docs to console


### PR DESCRIPTION
## what
- Add homebrew update action
- Add homebrew install instructions

## why
- Show the community that action-docs is even easier to install on osx
- Keep the formula up to date

## references
- Closes #666 
- Depends on PR https://github.com/Homebrew/homebrew-core/pull/195773
- https://github.com/mislav/bump-homebrew-formula-action