### PR TITLE
feat: Add pre-commit hooks.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+- id: action-docs
+  args:
+    - "--no-banner"
+    - "--update-readme"
+  description: Generate and update documentation for GitHub actions or workflows
+  entry: action-docs
+  files: "action\\.yml"
+  stages:
+    - pre-commit
+    - pre-merge-commit
+    - pre-push
+    - manual
+  language: node
+  name: action-docs
+  pass_filenames: false
+  require_serial: false


### PR DESCRIPTION
This add pre-commit hook. Usage example:

```yaml
  - repo: https://github.com/npalm/action-docs
    rev: v2.5.x
    hooks:
      - id: action-docs
```

Using this hook requires `pre-commit` [PR](https://github.com/pre-commit/pre-commit/pull/3460) merged.